### PR TITLE
InfluxDB 2 Updates

### DIFF
--- a/wiperf_poller/exporters/exportresults.py
+++ b/wiperf_poller/exporters/exportresults.py
@@ -80,8 +80,9 @@ class ResultsExporter(object):
 
             # construct url
             host = config_vars['data_host']
+            scheme = 'https' if config_vars['influx2_ssl'] else 'http'
             if is_ipv6(host): host = "[{}]".format(host)
-            influx_url = "https://{}:{}".format(host, config_vars['data_port'])
+            influx_url = "{}://{}:{}".format(scheme, host, config_vars['data_port'])
 
             sent_ok = self.send_results_to_influx2(gethostname(), influx_url, config_vars['influx2_token'],
                     config_vars['influx2_bucket'], config_vars['influx2_org'], results_dict, data_file, file_logger)

--- a/wiperf_poller/exporters/influxexporter2.py
+++ b/wiperf_poller/exporters/influxexporter2.py
@@ -18,7 +18,7 @@ except ImportError as error:
 # TODO: convert to class
 
 def time_lookup():
-    return datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
+    return datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def influxexporter2(localhost, url, token, bucket, org, dict_data, source, file_logger):


### PR DESCRIPTION
This PR addresses two issues:

- Use the `influx2_ssl` config variable to adjust the URL scheme (https vs http)
- The `time_lookup` function should return UTC time instead of local time (corresponds with strftime format ending with Z)
